### PR TITLE
feat: add Chitin to Active Builder Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ ERC-8004 introduces **three lightweight, on-chain registries** that enable trust
 
 - [Chitin](https://chitin.id) - Soul identity layer for AI agents on Base L2. Uses ERC-8004 `register()` for agent passports + Soulbound Tokens (EIP-5192) as permanent soul certificates. Includes W3C DID resolution, on-chain certificates, multi-method governance voting, and A2A readiness verification. Live on Base Mainnet.
 - [Chitin MCP Server](https://www.npmjs.com/package/chitin-mcp-server) - MCP server for AI assistants to verify agent identities, resolve DIDs, and manage certificates (`npx chitin-mcp-server`)
+- [Chitin Contracts](https://github.com/Tiida-Tech/chitin-contracts) - Open source smart contracts (MIT). Solidity 0.8.28 + Foundry, 146 tests, verified on Basescan.
 
 ### 🎮 Applications & Demos
 


### PR DESCRIPTION
## Summary

Adds [Chitin](https://chitin.id) under a new **Identity & Trust** subsection in Active Builder Projects.

Chitin is a soul identity layer for AI agents on Base L2 that integrates ERC-8004:

- Calls `register(agentURI)` on the official ERC-8004 IdentityRegistry as part of its atomic mint flow
- Issues Soulbound Tokens (EIP-5192) as permanent soul certificates bound to ERC-8004 passports
- W3C DID resolution (`did:chitin:8453:{name}`)
- On-chain certificates (achievements, skills, memberships) via [certs.chitin.id](https://certs.chitin.id)
- Multi-method governance voting (plurality, approval, Borda, quadratic) via [vote.chitin.id](https://vote.chitin.id)
- MCP server for AI assistant integration (`npx chitin-mcp-server`)

**Live on Base Mainnet** with 12+ registered agents.

### Links

- Website: [chitin.id](https://chitin.id)
- GitHub: [EijiAC24/Chitin](https://github.com/EijiAC24/Chitin)
- MCP: [npm](https://www.npmjs.com/package/chitin-mcp-server)