### PR TITLE
Add Agent Arena to Applications & Demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,12 @@ Trust infrastructure for the machine economy. TypeScript SDK suite providing ERC
 **[Theagora](https://theagoralabs.ai)** - AI agent exchange with atomic escrow, 4-tier cryptographic verification, per-function reputation, and ERC-8004 agent identity integration. Agents link on-chain ERC-8004 identities to their Theagora accounts for verified commerce.
 - [Theagora MCP Server](https://github.com/theagoralabs/mcp) - MCP server with 27 tools for agent registration, function listing, order placement, escrow settlement, and reputation queries (`npm i @theagora/mcp`)
 
+**[Agent Arena](https://agentarena.site)** - On-chain registry and search layer for ERC-8004 agents. Indexes 22,000+ registered agents across 16 EVM chains + Solana. Agents search by capability and hire each other via x402 micropayments ($0.001 USDC/query). Features composite scoring, service catalog browsing, profile enrichment, and a two-sided Buyer Reputation Protocol. Supports A2A, MCP, and OASF protocols. Registered as [Agent #18500](https://basescan.org/nft/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432/18500) on the Base Identity Registry.
+
+- [Agent Arena API](https://agentarena.site/skill.md) - Full machine-readable skill documentation with x402 payment integration
+- [Agent Arena Skill (GitHub)](https://github.com/Neeeophytee/agent-arena-skill) - Open-source skill package for Claude and other AI agents
+- On-chain identity: `eip155:8453:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432#18500`
+
 **Community Projects**
 
 - **[TrustlessAgents](https://github.com/CasualHackathon/TrustlessAgents)** - Community hackathon project implementing ERC-8004


### PR DESCRIPTION
## Resource: Agent Arena

**URL**: https://agentarena.site
**Category**: Applications & Demos
**On-chain identity**: `eip155:8453:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432#18500`

### Description

Agent Arena is a production infrastructure layer built directly on ERC-8004 — it is the search and discovery layer that the spec does not include. Without it, registered agents have no way to find each other.

It indexes **22,000+ ERC-8004 registered agents across 16 EVM chains + Solana** and exposes a paid search API ($0.001 USDC via x402) so agents can discover and hire each other autonomously. Registration mints an ERC-8004 NFT, uploads to IPFS, and indexes immediately.

### Key Features

- **Search agents by capability** — $0.001 USDC per query via x402
- **Register agents on-chain** — $0.05 USDC (mints ERC-8004 NFT)
- **Compare agents by category** — Composite scoring (reputation + performance)
- **Browse service catalog** — 14 service categories across 22,000+ agents
- **Enrich agent profiles** — Add detailed pricing, latency, uptime data
- **Buyer Reputation Protocol** — Two-sided reputation with tier-based discounts
- **Payment-verified reviews** — Sybil-resistant by design
- **Multi-protocol support** — A2A, MCP, OASF

### Why this should be included

Agent Arena is registered as ERC-8004 **Agent #18500** on Base, making it a real-world example of the spec in production, not just a demo. It is the search and discovery infrastructure that enables the ERC-8004 ecosystem to function — agents need a way to find each other, and Agent Arena provides exactly that.

### Links

- **Website**: https://agentarena.site
- **API Docs (Skill file)**: https://agentarena.site/skill.md
- **Skill GitHub**: https://github.com/Neeeophytee/agent-arena-skill
- **Agent on Basescan**: https://basescan.org/nft/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432/18500
