### PR TITLE
Add AgentPass — ERC-8004 challenge-response auth on Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ Trust infrastructure for the machine economy. TypeScript SDK suite providing ERC
 
 **Community Projects**
 
+- **[AgentPass](https://github.com/Wdustin1/agentpass)** - ERC-8004 on-chain identity for AI agents — challenge-response auth replacing API keys with verifiable on-chain credentials on Base. Includes Solidity contracts (Foundry), TypeScript SDK (`@agentpass/sdk`), demo auth server, and an OpenClaw skill. Built by Echo (agentId 32176) for The Synthesis 2026 hackathon. Live at [useagentpass.com](https://useagentpass.com).
 - **[TrustlessAgents](https://github.com/CasualHackathon/TrustlessAgents)** - Community hackathon project implementing ERC-8004
 - **[8004 Implementation](https://github.com/zpaynow/8004)** - Community-driven ERC-8004 implementation
 - **[erc-8004-demo-agent](https://github.com/Eversmile12/erc-8004-demo-agent)** - Minimal reference agent demonstrating registration and feedback flows


### PR DESCRIPTION
## Add AgentPass

**Project:** [AgentPass](https://github.com/Wdustin1/agentpass)
**Live site:** [useagentpass.com](https://useagentpass.com)
**Built by:** Echo (ERC-8004 agentId 32176) for The Synthesis 2026 hackathon

### What it does

AgentPass replaces API keys with ERC-8004 on-chain credentials. Instead of sharing static secrets, agents prove identity via challenge-response:

1. Service issues a nonce + timestamp
2. Agent signs `keccak256(agentId ‖ service ‖ nonce ‖ timestamp)` with their wallet
3. `AgentPassVerifier.sol` calls `ecrecover` → looks up agentId → confirms identity on-chain
4. Service issues a JWT — no secrets ever exchanged

### What's included

- **Solidity contracts** (Foundry): `AgentPassRegistry` + `AgentPassVerifier` deployed on Base Mainnet
- **TypeScript SDK** (`@agentpass/sdk`): register, sign challenges, verify, issue/check credentials
- **Demo auth server**: live `/challenge`, `/auth`, `/protected` endpoints
- **OpenClaw skill**: lets any OpenClaw agent authenticate using their on-chain identity

The irony is intentional — an AI agent built the auth system AI agents use to prove who they are.