### PR TITLE
Add Agent Veil Protocol — EigenTrust compute layer for ERC-8004

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,8 @@ Trust infrastructure for the machine economy. TypeScript SDK suite providing ERC
 
 ### Identity & Trust
 
+**[Agent Veil Protocol](https://agentveil.dev)** — Off-chain EigenTrust compute layer for ERC-8004. Graph-based trust scores with Sybil detection, collusion resistance, and signed attestations. Python SDK, MCP server, CrewAI/LangGraph/AutoGen integrations. [SDK](https://pypi.org/project/agentveil/) · [GitHub](https://github.com/creatorrmode-lead/avp-sdk) · [Bridge](https://agentveil.dev/v1/bridge/erc8004/{did}/attestation)
+
 ### Agent Services (x402 + ERC-8004)
 
 **[xbird](https://github.com/checkra1neth/xbird-skill)**


### PR DESCRIPTION
## Summary

Adds **Agent Veil Protocol** to the **Identity & Trust** section.

AVP is an off-chain EigenTrust compute layer for ERC-8004 — it computes graph-based trust scores with Sybil detection and collusion resistance, then returns signed attestations with Merkle proofs that agents write to ReputationRegistry via `giveFeedback()` using their own wallet. AVP holds no wallet and pays no gas.

- **SDK**: [pypi.org/project/agentveil](https://pypi.org/project/agentveil/) (`pip install agentveil`)
- **GitHub**: [github.com/creatorrmode-lead/avp-sdk](https://github.com/creatorrmode-lead/avp-sdk)
- **Bridge endpoint**: `GET /v1/bridge/erc8004/{did}/attestation`
- **Site**: [agentveil.dev](https://agentveil.dev)

## Why Identity & Trust section

AVP provides the trust computation layer that ERC-8004 intentionally leaves open — reputation aggregation, Sybil resistance, and dispute resolution on top of raw on-chain feedback.

Integrated with [Microsoft Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit/pull/1010) as official TrustProvider.