### PR TITLE
add: mcp8004 — MCP auth middleware using ERC-8004 onchain agent identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ The `type`, `name`, `description`, and `image` fields ensure compatibility with 
 
 ### Infrastructure & SDKs
 
+**[mcp8004](https://github.com/jordanlyall/mcp8004)**
+
+- Drop-in MCP auth middleware using ERC-8004 onchain agent identity. Agents authenticate to MCP servers by signing a challenge with their wallet; the server verifies against the ERC-8004 Identity Registry on Base and issues a scoped JWT session token. Includes x402 payment fallback for unregistered agents. `npm install mcp8004`. MIT licensed.
+
 **[UFX Agentic Commerce](https://github.com/ufosearchspace-create/ERC8183)**
 
 - [ERC-8183 Hook & Reputation Middleware](https://github.com/ufosearchspace-create/ERC8183) - First `IACPHook` implementations and ERC-8004 reputation bridge for ERC-8183 (Agentic Commerce Protocol). Includes ReputationHook (auto-writes job outcomes to ReputationRegistry), ReputationGateHook (reputation-based funding gate), SLAHook (deadline enforcement), AI evaluators, and Python SDK. 208 Solidity tests (incl. 9 fuzz). Live on Base Mainnet with [Iamalive Agent #1734](https://basescan.org/address/0x3F41E8699D774Eb738967A6506B3A9E919aA1c8B). MIT licensed.


### PR DESCRIPTION
## What is mcp8004?

[mcp8004](https://github.com/jordanlyall/mcp8004) is a drop-in auth middleware for MCP servers that verifies agent identity using ERC-8004 onchain.

**The problem it solves:** When agents call other agents' MCP servers, the server has no way to verify who's calling. mcp8004 fixes that — agent signs a challenge with its wallet, server checks the ERC-8004 Identity Registry on Base, issues a scoped JWT session token. No API keys, no OAuth.

**Features:**
- ERC-8004 identity verification on Base Sepolia + Base Mainnet
- Scoped JWT session tokens (`tools:all` for registered agents, `tools:public` for others)
- x402 payment fallback for unregistered agents
- 3-line integration: `server.use(authMiddleware({ chainId: 84532 }))`

**Links:**
- GitHub: https://github.com/jordanlyall/mcp8004
- npm: https://www.npmjs.com/package/mcp8004
- Blog post: https://jordanlyall.com/notes/when-agents-call-agents