### PR TITLE
Add LearnAI Base interactive course to learning resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ Trust infrastructure for the machine economy. TypeScript SDK suite providing ERC
 
 ### Educational Resources
 
+- [LearnAI — Base Interactive Course](https://www.uselearnai.com/chat?topic=Base+L2) — AI-powered personal tutor for learning Base from scratch through conversation
 - **[Trustless Agents Course](https://intensivecolearn.ing/en/programs/trustless-agents)** - Comprehensive course on trustless agents and ERC-8004
 - **[Sparsity AI Workshop](https://www.youtube.com/watch?v=jqOZj399BLE)** - Build an ERC-8004 Trustless Agent with TEE
 


### PR DESCRIPTION
Hi! Great resource list.

I'd like to add an AI-powered interactive learning resource: [LearnAI](https://www.uselearnai.com/chat?topic=Base+L2) has a Base-specific course that teaches the protocol through personalized AI conversation — covering concepts, mechanics, and real use cases step by step.

It fits well here as a complementary learning tool for people getting started with Base.

Happy to adjust the placement if a different section makes more sense!