### PR TITLE
Add AgentTalk to Collaboration Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,12 @@ The `type`, `name`, `description`, and `image` fields ensure compatibility with 
 
 ### Collaboration Frameworks
 
+**[AgentTalk](https://github.com/douglasborthwick-crypto/agenttalk)** — _Condition-gated sessions for agent-to-agent communication_
+
+- [AgentTalk](https://github.com/douglasborthwick-crypto/agenttalk) - Wallet auth for A2A: before two agents exchange data, both verify their wallets satisfy the same on-chain conditions (token balances, NFT ownership, compliance attestations). Supports bilateral (2 agents) and multi-party ("town hall") flows across 33 chains. Re-verify on demand ejects agents who lose credentials mid-session. Sessions issued as ECDSA P-256 signed JWTs (`kid: insumer-attest-v1`), verifiable offline via [JWKS](https://insumermodel.com/.well-known/jwks.json).
+- [Examples (JS/Python/Shell)](https://github.com/douglasborthwick-crypto/agenttalk/tree/main/examples) - Bilateral and multi-party session flows
+- [Hosted API](https://skyemeta.com/agenttalk/) - 10 calls per wallet, no signup required
+
 ### Commerce & Escrow
 
 **[UFX Agentic Commerce](https://github.com/ufosearchspace-create/ERC8183)** — First `IACPHook` implementations and ERC-8004 reputation bridge for ERC-8183 (Agentic Commerce Protocol). The EIP defines hooks; we built and deployed them.


### PR DESCRIPTION
Adds AgentTalk to the Collaboration Frameworks section (currently empty).

AgentTalk is a condition-gated session layer for agent-to-agent communication. Before two agents exchange data, both verify their wallets satisfy the same on-chain conditions (token balances, NFT ownership, compliance attestations). The session JWT is an ECDSA P-256 signed attestation (`kid: insumer-attest-v1`), verifiable offline via JWKS — no callback required. Bilateral and multi-party ("town hall") flows, 33 chains, re-verify ejects agents who lose credentials mid-session.

Complements the existing InsumerAPI entry (verification primitive) with the A2A session layer built on top of it.

Disclosure: I maintain AgentTalk and the related InsumerAPI entry already listed in this repo.