### PR TITLE
Add CardZero — production ERC-8004 + ERC-8183 reference implementation on Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,15 @@ The `type`, `name`, `description`, and `image` fields ensure compatibility with 
 - [ERC-8004 Example](https://github.com/vistara-apps/erc-8004-example)
 - **[Verity Protocol](https://verity.tenpound.xyz)** — On-chain reliability scoring for ERC-8004 agents. Indexes `NewFeedback` events from the `ReputationRegistry`, computes Brier Skill Scores across Economic, Solver, and Governance verticals, submits reputation back via `giveFeedback` after each scoring cycle, and anchors every score as an EAS attestation on Base. SDK: [`@veritynpm/sdk`](https://www.npmjs.com/package/@veritynpm/sdk).
 
+**[CardZero](https://cardzero.ai)** — Production smart-contract wallet built specifically for AI agents on Base mainnet. Two-actor identity model: human Owner controls policy via web dashboard (no Web3 wallet required); AI Agent transacts USDC via API key bound to an on-chain session key. Spending rules (per-tx limit, daily cap, address whitelist, expiry, freeze) enforced on-chain. Full open-source reference implementation of ERC-8004 + ERC-8183 deployed alongside the canonical registry — same interfaces, custom self-deployed contracts. 133 contract tests; 4-EOA role separation (deployer / registrar / attestor / evaluator).
+
+- [CardZeroIdentityRegistry (Base)](https://basescan.org/address/0x1db9b790ae49def806d3d16172de04d2557fecbe) - UUPS-upgradeable ERC-8004 IdentityRegistry; canonical interface (`agentURI`, `agentId`, EIP-712 wallet binding); `REGISTRAR_ROLE` gated.
+- [CardZeroReputationRegistry (Base)](https://basescan.org/address/0xc00a5757c63d65005d22e507eae045df5e83b338) - UUPS-upgradeable ReputationRegistry with pinned `scoringRulesHash` on-chain; rules at [cardzero.ai/SCORING-RULES.md](https://cardzero.ai/SCORING-RULES.md). EIP-712 + ERC-1271 dual-path attestation signatures, value range `[-10, 20]`.
+- [CardZeroJobs (Base)](https://basescan.org/address/0xb28a0cca5ac28466f3d175f35b97aa104d4c4ba8) - ERC-8183 service-delivery escrow with USDC + Evaluator role + auto-reputation reflection on `finalizeJob`. Real mainnet E2E verified (`createJob → approve → fund → submit → complete` in 5 txs; splits enforced 93%/5%/2%).
+- [cardzero-mcp (npm)](https://www.npmjs.com/package/cardzero-mcp) - 10-tool MCP server (payments, x402 buyer, Job lifecycle); `npx cardzero-mcp`.
+- [Public agent cards](https://cardzero.ai/.well-known/agent/) and reputation feed at `/v1/reputation/{walletAddress}`.
+- [GitHub](https://github.com/mrocker/CardZero) - Full source, OpenAPI spec, 27-page docs at [cardzero.ai/docs](https://cardzero.ai/docs), single-file LLM corpus at [/llms-full.txt](https://cardzero.ai/llms-full.txt).
+
 ### Collaboration Frameworks
 
 ### Commerce & Escrow


### PR DESCRIPTION
Adds CardZero under **Builder Projects → Infrastructure & SDKs**.

**Why a new entry:** CardZero ships a self-deployed UUPS-upgradeable reference implementation of **both** ERC-8004 (Identity + Reputation) **and** ERC-8183 (Service Escrow) on Base mainnet, plus a production smart-wallet built around them. To my knowledge this is the first deployment that ties all three contracts together end-to-end.

**Note on framing:** CardZero deploys its own registries (parallel to the canonical `0x8004A169...`) using the canonical interfaces. We are not registered as an Agent on the canonical registry — we *are* a registry. This may be relevant if you want to file the entry under "alternative deployments" rather than mixed in with canonical-registered agents; happy to adjust.

**Mainnet contracts:**
- IdentityRegistry: [`0x1db9b790ae49def806d3d16172de04d2557fecbe`](https://basescan.org/address/0x1db9b790ae49def806d3d16172de04d2557fecbe)
- ReputationRegistry: [`0xc00a5757c63d65005d22e507eae045df5e83b338`](https://basescan.org/address/0xc00a5757c63d65005d22e507eae045df5e83b338)
- Jobs (ERC-8183): [`0xb28a0cca5ac28466f3d175f35b97aa104d4c4ba8`](https://basescan.org/address/0xb28a0cca5ac28466f3d175f35b97aa104d4c4ba8)

**Beyond the contracts:**
- Production API ([api.cardzero.ai](https://api.cardzero.ai)) with full OpenAPI spec.
- Open-source MCP server ([`cardzero-mcp@0.2.0`](https://www.npmjs.com/package/cardzero-mcp)).
- Public agent cards at `/.well-known/agent/{address}` per ERC-8004 spec.
- Real mainnet E2E job lifecycle verified — 5 txs, splits enforced on-chain.
- 27-page docs at [cardzero.ai/docs](https://cardzero.ai/docs), single-file LLM corpus at [/llms-full.txt](https://cardzero.ai/llms-full.txt).

**Repo:** [mrocker/CardZero](https://github.com/mrocker/CardZero) (133 contract tests, internal audit report, 4 separated EOAs by role).

Open to feedback on entry placement / framing — happy to revise.
