### PR TITLE
Add 2s to Agent Services (x402 + ERC-8004)

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,15 @@ Off-chain EigenTrust compute layer for ERC-8004. Graph-based trust scores with S
 - [Multi-Chain Registration Report (GitHub Issue #72)](https://github.com/erc-8004/erc-8004-contracts/issues/72) - Detailed experience report from registering on 4 chains with ecosystem review data
 - [@agentLaplace on X](https://x.com/agentLaplace) - Crypto intelligence, agent economy coverage, and ERC-8004 ecosystem analysis
 
+
+**[2s](https://2s.io)**
+
+- [2s API](https://2s.io) - The everything API for AI agents: 570+ pay-per-call endpoints across public records, finance, crypto, legal, health, geo, security, and EDI. Settled in USDC via x402 on Base + Solana — no signup, no API keys.
+- [@2sio/mcp](https://www.npmjs.com/package/@2sio/mcp) - Hosted + stdio MCP server exposing every endpoint as an agent tool (`npx -y @2sio/mcp`); also live at `https://2s.io/mcp`.
+- [Agent Card](https://2s.io/.well-known/agent-card.json) - ERC-8004 + A2A compliant agent card with a live `/a2a` JSON-RPC transport.
+- Registered on ERC-8004 Identity Registry on Base (`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`, agent #57911)
+
+
 ### Applications & Demos
 
 **[AgentStamp](https://agentstamp.org)**


### PR DESCRIPTION
Adds **2s** to **Builder Projects → Agent Services (x402 + ERC-8004)**.

2s is an ERC-8004-registered agent offering ground-truth data as pay-per-call HTTP endpoints, settled in USDC via x402 (no signup, no API keys).

- Registered on the ERC-8004 Identity Registry on Base (`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`, agent #57911) — same registry as several existing entries in this section.
- Serves an ERC-8004 agent manifest (`/.well-known/agent.json`) and an A2A-compliant agent card (`/.well-known/agent-card.json`) with a live `/a2a` JSON-RPC transport.
- 570+ endpoints exposed via a hosted + stdio MCP server (`@2sio/mcp`).

One entry added under the existing Agent Services subsection; formatting matches neighboring entries.