### PR TITLE
Add: ArcBounty (bounty marketplace on ERC-8183 escrow + ERC-8004 identity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,12 @@ Identity, marketplace, and services platform for AI agents on Base L2. Productio
 - [ERC-8004 Identity Registry (Base Mainnet)](https://basescan.org/address/0x08591b838Bd745AFBafE27c254676A3C6Fafb159) - On-chain agent identity with behavioral KYA attestations
 - [MCP Server](https://agentlux.ai) - 32+ tools for agent identity, marketplace, avatar, and services integration
 
+**[ArcBounty](https://arcbounty.app)** — A bounty marketplace on Arc Network: a poster escrows USDC (ERC-8183), any registered agent (ERC-8004 identity) or human takes the job, submits work, and gets paid automatically on approval. Reputation is written on-chain only after a real payout — task-backed, not review-based. 101 tests + invariants + Slither clean, all public.
+
+- [Code](https://github.com/Sofiia7/ARC) - Contracts, TypeScript SDK, MCP server, and an x402-priced facade API
+- [App](https://arcbounty.app) - Live bounty board (Arc Testnet), on-chain stats dashboard
+- [arcbounty-agent-sdk](https://www.npmjs.com/package/arcbounty-agent-sdk) / [arcbounty-mcp](https://www.npmjs.com/package/arcbounty-mcp) - npm packages for agent integration; arcbounty-mcp is also in the official MCP Registry (io.github.Sofiia7/arcbounty-mcp)
+
 ### Verification & Identity
 
 **[ORIGIN Protocol](https://origindao.ai)** — _Proof of Agency: Cognitive verification for AI agents_

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Identity, marketplace, and services platform for AI agents on Base L2. Productio
 - [Code](https://github.com/Sofiia7/ARC) - Contracts, TypeScript SDK, MCP server, and an x402-priced facade API
 - [App](https://arcbounty.app) - Live bounty board (Arc Testnet), on-chain stats dashboard
 - [arcbounty-agent-sdk](https://www.npmjs.com/package/arcbounty-agent-sdk) / [arcbounty-mcp](https://www.npmjs.com/package/arcbounty-mcp) - npm packages for agent integration; arcbounty-mcp is also in the official MCP Registry (io.github.Sofiia7/arcbounty-mcp)
+- [BountyAdapter (verified)](https://testnet.arcscan.app/address/0x538CD48789667168bfb36f838Af8476237F9409F) - Proof of life: agent #847205 took jobIds 155220 and 155219 and was paid through canonical ERC-8183 escrow, with feedback written to the ERC-8004 registry
 
 ### Verification & Identity
 


### PR DESCRIPTION
Adds [ArcBounty](https://arcbounty.app) to the Commerce & Escrow section under Builder Projects — a bounty marketplace on Arc Network built on ERC-8183 (escrow) + ERC-8004 (agent identity/reputation): a poster escrows USDC, any registered agent or human takes the job, submits work, and gets paid automatically on approval.

Open source (MIT): https://github.com/Sofiia7/ARC