### PR TITLE
Add ByKaranteli (Agent Services: x402 + ERC-8004)

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ Off-chain EigenTrust compute layer for ERC-8004. Graph-based trust scores with S
 **[ByKaranteli](https://bykaranteli.com)**
 
 - Crypto derivatives data agent registered on the ERC-8004 Identity Registry on X Layer as agent [#10642](https://8004scan.io/agents/xlayer/10642) (`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`), serving the same data over MCP and x402.
-- [bykaranteli-mcp](https://www.npmjs.com/package/bykaranteli-mcp) - MIT-licensed MCP server with 20 read-only tools covering funding rates, open interest, liquidations, options flow, ETF flows, CFTC COT positioning and order-flow toxicity. No API key.
+- [bykaranteli-mcp](https://www.npmjs.com/package/bykaranteli-mcp) - MIT-licensed MCP server with 33 read-only tools covering funding rates, open interest, liquidations, options flow, ETF flows, CFTC COT positioning and order-flow toxicity. No API key.
 - [Hosted MCP endpoint](https://bykaranteli.com/developers) - Streamable-HTTP remote at `https://mcp.bykaranteli.com`, published in the official MCP registry as `com.bykaranteli/mcp`, so no local install is needed.
 - [x402 endpoints](https://bykaranteli.com/api/x402) - Thirteen pay-per-call data endpoints priced $0.002-$0.010 and settled in USDC on Solana and Base mainnet: liquidation maps and raw liquidation events, funding and open-interest history, Deribit options tape and options open interest, DVOL, CFTC COT, Coinbase premium, slippage ladders, listing history, and VPIN order-flow toxicity.
 - [crypto-datasets](https://github.com/bykarantelicom/crypto-datasets) - CC0 daily crypto derivatives datasets in CSV and JSON, updated by an automated pipeline.

--- a/README.md
+++ b/README.md
@@ -399,6 +399,14 @@ Off-chain EigenTrust compute layer for ERC-8004. Graph-based trust scores with S
 - [Multi-Chain Registration Report (GitHub Issue #72)](https://github.com/erc-8004/erc-8004-contracts/issues/72) - Detailed experience report from registering on 4 chains with ecosystem review data
 - [@agentLaplace on X](https://x.com/agentLaplace) - Crypto intelligence, agent economy coverage, and ERC-8004 ecosystem analysis
 
+**[ByKaranteli](https://bykaranteli.com)**
+
+- Crypto derivatives data agent registered on the ERC-8004 Identity Registry on X Layer as agent [#10642](https://8004scan.io/agents/xlayer/10642) (`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`), serving the same data over MCP and x402.
+- [bykaranteli-mcp](https://www.npmjs.com/package/bykaranteli-mcp) - MIT-licensed MCP server with 20 read-only tools covering funding rates, open interest, liquidations, options flow, ETF flows, CFTC COT positioning and order-flow toxicity. No API key.
+- [Hosted MCP endpoint](https://bykaranteli.com/developers) - Streamable-HTTP remote at `https://mcp.bykaranteli.com`, published in the official MCP registry as `com.bykaranteli/mcp`, so no local install is needed.
+- [x402 endpoints](https://bykaranteli.com/api/x402) - Three pay-per-call data endpoints priced $0.002-$0.005 and settled in USDC on Solana and Base mainnet: liquidation-map levels, Deribit options tape, and VPIN order-flow toxicity.
+- [crypto-datasets](https://github.com/bykarantelicom/crypto-datasets) - CC0 daily crypto derivatives datasets in CSV and JSON, updated by an automated pipeline.
+
 ### Applications & Demos
 
 **[AgentStamp](https://agentstamp.org)**

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ Off-chain EigenTrust compute layer for ERC-8004. Graph-based trust scores with S
 - Crypto derivatives data agent registered on the ERC-8004 Identity Registry on X Layer as agent [#10642](https://8004scan.io/agents/xlayer/10642) (`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`), serving the same data over MCP and x402.
 - [bykaranteli-mcp](https://www.npmjs.com/package/bykaranteli-mcp) - MIT-licensed MCP server with 20 read-only tools covering funding rates, open interest, liquidations, options flow, ETF flows, CFTC COT positioning and order-flow toxicity. No API key.
 - [Hosted MCP endpoint](https://bykaranteli.com/developers) - Streamable-HTTP remote at `https://mcp.bykaranteli.com`, published in the official MCP registry as `com.bykaranteli/mcp`, so no local install is needed.
-- [x402 endpoints](https://bykaranteli.com/api/x402) - Three pay-per-call data endpoints priced $0.002-$0.005 and settled in USDC on Solana and Base mainnet: liquidation-map levels, Deribit options tape, and VPIN order-flow toxicity.
+- [x402 endpoints](https://bykaranteli.com/api/x402) - Thirteen pay-per-call data endpoints priced $0.002-$0.010 and settled in USDC on Solana and Base mainnet: liquidation maps and raw liquidation events, funding and open-interest history, Deribit options tape and options open interest, DVOL, CFTC COT, Coinbase premium, slippage ladders, listing history, and VPIN order-flow toxicity.
 - [crypto-datasets](https://github.com/bykarantelicom/crypto-datasets) - CC0 daily crypto derivatives datasets in CSV and JSON, updated by an automated pipeline.
 
 ### Applications & Demos


### PR DESCRIPTION
Adds ByKaranteli to **Builder Projects → Agent Services (x402 + ERC-8004)**, alongside the other agents in that section that pair an ERC-8004 identity with MCP and x402 endpoints.

**Correction (2026-08-09):** the first revision of this PR said "three x402 pay-per-call endpoints priced $0.002-$0.005" and MCP registry version `0.7.2`. Both are stale. I have pushed a commit fixing the README line. Current facts: **13 paid x402 endpoints priced $0.002 to $0.010**, and **`com.bykaranteli/mcp` v0.7.3**.

**Resource Information**

- Name: ByKaranteli
- URL: https://bykaranteli.com
- Category: Builder Projects → Agent Services (x402 + ERC-8004)
- Description: Crypto derivatives data agent registered on the ERC-8004 Identity Registry on X Layer (agent #10642), serving the same data over a 20-tool MCP server and 13 x402 pay-per-call endpoints.
- License: MCP server MIT, datasets CC0
- Maintenance Status: active

**Why it should be included**

It is a production ERC-8004 identity that actually resolves to working agent-accessible services, which is what this section collects. Everything in the entry is independently checkable:

- ERC-8004: `ownerOf(10642)` on the X Layer Identity Registry `0x8004A169FB4a3325136EB29fA0ceB6D2e539a432` returns `0x0db4c96d8b14f431f3bb8ce1a33f07d2c696a62c`. Explorer page: https://8004scan.io/agents/xlayer/10642
- MCP: `com.bykaranteli/mcp` v0.7.3 in the official MCP registry, declaring a streamable-http remote at https://mcp.bykaranteli.com. A `tools/list` call against that remote returns 20 tools. npm package: https://www.npmjs.com/package/bykaranteli-mcp (MIT, Node 18+, no API key).
- x402: all 13 endpoints listed by https://bykaranteli.com/api/x402 return HTTP 402 on an unpaid GET, priced $0.002 to $0.010, USDC on Solana and Base mainnet, settled through the Coinbase CDP facilitator.
- Datasets: https://github.com/bykarantelicom/crypto-datasets (CC0).

**Checklist**

- Searched the README for an existing ByKaranteli entry: none.
- Single section touched, 8 lines added, no other edits and no reformatting.
- Follows the CONTRIBUTING.md link format and the existing style of that section.
