### PR TITLE
Add erc-8004-liveness (Explorer & Scanner Tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@ Tools for browsing and querying on-chain ERC-8004 registries.
 - **[8004agents.ai](https://8004agents.ai)** - Agent discovery interface
 - **[trust8004.xyz](https://www.trust8004.xyz)** - Agent discovery and management tool
 - **[agenteconomy.to](https://agenteconomy.to)** - Real-time dashboard tracking ERC-8004 agent registry events on Base alongside x402, ERC-8183, and MPP protocols. Aggregated metrics, daily charts, and chain breakdowns refreshed every 6 hours
+- **[erc-8004-liveness](https://github.com/yaojin0609/erc-8004-liveness)** - Liveness measurement across 12 chains: two-round protocol-level endpoint probing 48h apart (A2A agent card, MCP initialize/tools-list), host-stratified reweighting, and cross-chain integrity reconciliation. Open dataset, methodology, and MIT-licensed scanner
 
 ## Research & Papers
 


### PR DESCRIPTION
Adds one entry to **Explorer & Scanner Tools**. Single-line diff.

**Resource Name**: erc-8004-liveness

**URL**: https://github.com/yaojin0609/erc-8004-liveness

**Category**: Explorer & Scanner Tools

**Description**: Liveness measurement of ERC-8004 registrations across 12 chains — two rounds of protocol-level endpoint probing at least 48h apart, host-stratified reweighting, and cross-chain integrity reconciliation. Open dataset and MIT-licensed scanner.

**Why it should be included**: The tools currently listed in this section index what is registered on-chain. This one measures whether the declared service endpoints actually respond — A2A agent card fetch and parse, MCP `initialize` + `tools/list` — in two rounds intersected per endpoint, so the result separates stable reachability from a single lucky sample. Snapshot 2026-08-10 covers 392,258 identities across 12 chains; the funnel, per-chain block heights, and the full methodology are in the repo, and a re-run on 2026-11-10 is committed to in the README.

Checked against CONTRIBUTING.md: publicly accessible, no login, working link, format matches the surrounding entries in that section, description is two sentences and non-promotional.

Note: CONTRIBUTING.md recommends issues for single additions. Happy to move this to an issue instead if that's easier — I opened a PR because the diff is one line and ready to merge as-is.
